### PR TITLE
Exclude `Tags` or 'cc' from fuzzysearch | Update _internal_utils.py

### DIFF
--- a/redbot/core/utils/_internal_utils.py
+++ b/redbot/core/utils/_internal_utils.py
@@ -135,6 +135,14 @@ async def fuzzy_command_search(
 
         if alias:
             return None
+
+    # If term is defined as a tag in the 'Tags' cog, excluding it from fuzzy search.
+    tags_cog = ctx.bot.get_cog("Tags")
+    if tags_cog is not None:
+        tag = tags_cog.get_tag(ctx.guild, term) or tags_cog.get_tag(None, term)
+        if tag:
+            return None
+
     customcom_cog = ctx.bot.get_cog("CustomCommands")
     if customcom_cog is not None:
         cmd_obj = customcom_cog.commandobj


### PR DESCRIPTION
- Check if term is defined as a tag in the `Tags` cog, excluding it from fuzzy search.
- Both for global tag AND for guild tag.

### Description of the changes



### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
No
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
